### PR TITLE
Hooking to PostEntityTakeDamage

### DIFF
--- a/lua/autorun/server/sv_hitdamagenumbers.lua
+++ b/lua/autorun/server/sv_hitdamagenumbers.lua
@@ -521,10 +521,8 @@ hook.Add( "PlayerAuthed", "hdn_initializePlayer", function(pl)
 end )
 
 hook.Add( "InitPostEntity", "hdn_postInitHook", function()
-	
-	-- Not a guarantee, but this should, in most cases, ensure that Hit Numbers is one of the last to hook to EntityTakeDamage
-	hook.Add( "EntityTakeDamage", "hdn_onEntDamage", onEntTakeDamage )
-
+	-- Hooks Hit Numbers, so that it displays all damage events
+	hook.Add( "PostEntityTakeDamage", "hdn_onEntDamage", onEntTakeDamage )
 end )
 
 -- Load server settings.

--- a/lua/autorun/server/sv_hitdamagenumbers.lua
+++ b/lua/autorun/server/sv_hitdamagenumbers.lua
@@ -520,10 +520,8 @@ hook.Add( "PlayerAuthed", "hdn_initializePlayer", function(pl)
 	
 end )
 
-hook.Add( "InitPostEntity", "hdn_postInitHook", function()
-	-- Hooks Hit Numbers, so that it displays all damage events
-	hook.Add( "PostEntityTakeDamage", "hdn_onEntDamage", onEntTakeDamage )
-end )
+-- Hooks Hit Numbers, so that it displays all damage events
+hook.Add( "PostEntityTakeDamage", "hdn_onEntDamage", onEntTakeDamage )
 
 -- Load server settings.
 if not loadSettings() then


### PR DESCRIPTION
Instead of trying to be the last addon, that gets hooked to EntityTakeDamage, just use PostEntityTakeDamage which contains all processed Damage Information.
https://wiki.facepunch.com/gmod/GM:PostEntityTakeDamage

Also resolves the issue, that for TTT Karma-related damage doesn't get shown.