### PR TITLE
Fixed Bug not showing Damage while Dying

### DIFF
--- a/lua/autorun/server/sv_hitdamagenumbers.lua
+++ b/lua/autorun/server/sv_hitdamagenumbers.lua
@@ -377,12 +377,12 @@ hook.Add( "PostEntityTakeDamage", "hdn_onPostEntDamage", function(target, dmginf
 			local targetIsNPC    = target:IsNPC()
 
 			-- Check masks.
-			if ( !mask_players and targetIsPlayer )
-			or ( !mask_npcs and targetIsNPC )
-			or ( !mask_ragdolls and target:IsRagdoll() )
-			or ( !mask_vehicles and target:IsVehicle() )
-			or ( !mask_props and entIsProp(target) )
-			or ( !mask_world and entIsWorld(target) )
+			if ( not mask_players and targetIsPlayer )
+			or ( not mask_npcs and targetIsNPC )
+			or ( not mask_ragdolls and target:IsRagdoll() )
+			or ( not mask_vehicles and target:IsVehicle() )
+			or ( not mask_props and entIsProp(target) )
+			or ( not mask_world and entIsWorld(target) )
 			then return end
 
 			local dmgAmount = dmginfo:GetDamage()


### PR DESCRIPTION
By adding a hook to entitytakedamage again, we save the health amount before taking damage and can therefore address if something is already dead like a ragdoll.
Therefore we gain the same inner workings as before we changed to the new PostEntityTakeDamage Hook and still enjoy the new features.

Solving #2 with that and also making some minor tweaks that where shown by the Glua linter, like using not and ~ instead of !.
Tested this and it works fine even when you enable masks for world and other stuff.